### PR TITLE
Fixes for foundation methods, add close_session method

### DIFF
--- a/asyncsleepiq/asyncsleepiq.py
+++ b/asyncsleepiq/asyncsleepiq.py
@@ -123,6 +123,10 @@ class AsyncSleepIQ:
                     body=resp.text,
                 ))           
 
+    async def close_session(self):
+        if self._session:
+            await self._session.close()
+
     async def put(self, url, data="", params={}):
         await self.__make_request(self._session.put, url, data, params)
         

--- a/asyncsleepiq/asyncsleepiq.py
+++ b/asyncsleepiq/asyncsleepiq.py
@@ -82,7 +82,7 @@ class AsyncSleepIQ:
         ) as resp:
 
             if resp.status == 401:
-                raise SleepIQLoginException("Incorect username or password")
+                raise SleepIQLoginException("Incorrect username or password")
             if resp.status == 403:
                 raise SleepIQLoginException("User Agent is blocked. May need to update GenUserAgent data?")
             if resp.status not in (200, 201):


### PR DESCRIPTION
I was testing the new integration in Home Assistant, but it wouldn't load because of this error:

```
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/usr/lib/python3.8/asyncio/base_events.py", line 616, in run_until_complete
    return future.result()
  File "<stdin>", line 4, in main
  File "/mnt/c/dev-workspace/asyncsleepiq/asyncsleepiq/asyncsleepiq.py", line 175, in init_beds
    await bed.foundation.fetch_features()
  File "/mnt/c/dev-workspace/asyncsleepiq/asyncsleepiq/foundation.py", line 56, in fetch_features
    features_flags = getattr(fs, 'fsBoardFeatures')
AttributeError: 'dict' object has no attribute 'fsBoardFeatures'
```

I was able to reproduce locally outside of Home Assistant. Made these changes and it's working with my account now.