### PR TITLE
add actuator and light classes

### DIFF
--- a/asyncsleepiq/actuator.py
+++ b/asyncsleepiq/actuator.py
@@ -1,0 +1,33 @@
+from .consts import ACTUATORS, ACTUATORS_FULL, SIDES, SIDES_FULL
+
+class SleepIQActuator:
+    def __init__(self, api, bed_id, side, actuator):
+        self._api = api
+        self.bed_id = bed_id
+        self.side = SIDES[side] if side else None
+        self.side_full = SIDES_FULL[side] if side else None
+        self.actuator = ACTUATORS[actuator]
+        self.actuator_full = ACTUATORS_FULL[actuator]
+        self.position = 0
+
+    def __str__(self):
+        return f"SleepIQActuator[{self.actuator_full} {self.side_full}], position={self.position}"
+    def __repr__(self):
+        return f"SleepIQActuator[{self.actuator_full} {self.side_full}], position={self.position}"
+
+    async def set_position(self, position, slowSpeed=False):
+        if position < 0 or position > 100:
+            raise ValueError("Invalid position, must be between 0 and 100")
+        if position == self.position:
+            return
+        data = {"position": position, "side": self.side if self.side else "R", "actuator": self.actuator, "speed": 1 if slowSpeed else 0}
+        await self._api.put(f"bed/{self.bed_id}/foundation/adjustment/micro", data)
+
+    async def update(self, data):
+        # For non-split actuators, it doesn't matter which side we get the
+        # value from, it'll always be the same for either
+        side_full = self.side_full if self.side_full else "Right"
+
+        # The API reports position in hex, but is set with an integer.
+        # We'll always show position with an integer value.
+        self.position = int(data[f"fs{side_full}{self.actuator_full}Position"], 16)

--- a/asyncsleepiq/asyncsleepiq.py
+++ b/asyncsleepiq/asyncsleepiq.py
@@ -177,6 +177,7 @@ class AsyncSleepIQ:
         # init foundations
         for bed in self.beds.values():
             await bed.foundation.fetch_features()
+            await bed.foundation.init_actuators()
             await bed.foundation.init_lights()
         
     # update statuses of sleepers/beds
@@ -188,5 +189,5 @@ class AsyncSleepIQ:
                 self.beds[bed_status['bedId']].sleepers[i].in_bed = bed_status[side+'Side']['isInBed']
                 self.beds[bed_status['bedId']].sleepers[i].pressure = bed_status[side+'Side']['pressure']
                 self.beds[bed_status['bedId']].sleepers[i].sleep_number = bed_status[side+'Side']['sleepNumber']
-        
-        
+        for bed in self.beds.values():
+            await bed.foundation.update_actuators()

--- a/asyncsleepiq/asyncsleepiq.py
+++ b/asyncsleepiq/asyncsleepiq.py
@@ -189,5 +189,3 @@ class AsyncSleepIQ:
                 self.beds[bed_status['bedId']].sleepers[i].in_bed = bed_status[side+'Side']['isInBed']
                 self.beds[bed_status['bedId']].sleepers[i].pressure = bed_status[side+'Side']['pressure']
                 self.beds[bed_status['bedId']].sleepers[i].sleep_number = bed_status[side+'Side']['sleepNumber']
-        for bed in self.beds.values():
-            await bed.foundation.update_actuators()

--- a/asyncsleepiq/consts.py
+++ b/asyncsleepiq/consts.py
@@ -59,3 +59,6 @@ SIDES = ['L', 'R']
 SIDES_FULL= ['Left', 'Right']
 
 FOUNDATION_TYPES = ['single', 'splitHead', 'splitKing','easternKing']
+
+ACTUATORS = ['H', 'F']
+ACTUATORS_FULL = ['Head', 'Foot']

--- a/asyncsleepiq/light.py
+++ b/asyncsleepiq/light.py
@@ -1,0 +1,28 @@
+class SleepIQLight:
+    def __init__(self, api, bed_id, outlet_id):
+        self._api = api
+        self.bed_id = bed_id
+        self.is_on = False
+        self.outlet_id = outlet_id
+
+    def __str__(self):
+        return f"SleepIQLight[{self.outlet_id}]: {'On' if self.is_on else 'Off'}"
+    def __repr__(self):
+        return f"SleepIQLight[{self.outlet_id}]: {'On' if self.is_on else 'Off'}"
+
+    async def turn_on(self):
+        await self.set_light(True)
+        self.is_on = True
+
+    async def turn_off(self):
+        await self.set_light(False)
+        self.is_on = False
+
+    async def set_light(self, on):
+        data = {"outletId": self.outlet_id, "setting": 1 if on else 0}
+        await self._api.put(f"bed/{self.bed_id}/foundation/outlet", data)
+
+    async def update(self):
+        params = {"outletId": self.outlet_id}
+        status = await self._api.get(f"bed/{self.bed_id}/foundation/outlet", params=params)
+        self.is_on = status["setting"] == 1


### PR DESCRIPTION
I designed this with the intention that actuators are updated in the same call for updating the sleeper statuses (it will skip the api call if the foundation doesn't support it). 

The update for the lights is decoupled because it has to call the api for each light, and I want to make sure those calls get skipped if the light isn't being used in Home Assistant.

One thing to consider is setting the position of multiple actuators at the same time. Whichever is called last is the one that will stick. It would be nice to figure out a way for the foundation class to coordinate them so only one actuator can actually be setting the position at any given time.