### PR TITLE
Fix subscripting NoneType error with single sleeper

### DIFF
--- a/asyncsleepiq/asyncsleepiq.py
+++ b/asyncsleepiq/asyncsleepiq.py
@@ -53,6 +53,8 @@ class AsyncSleepIQ(SleepIQAPI):
             if bed_status["bedId"] not in self.beds:
                 continue
             for i, side in enumerate(["left", "right"]):
+                if bed_status[side+'Side'] is None:
+                    continue
                 self.beds[bed_status["bedId"]].sleepers[i].in_bed = bed_status[
                     side + "Side"
                 ]["isInBed"]


### PR DESCRIPTION
With the update to homeassistant 2022.3(which changed from sleepyq to asyncsleepiq) I started getting these errors. My bed is a single-envelope model with only one side. The left side returns Nones for the data in this case.

Validated on my home-assistant install by making the change, restarting, confirming that I no longer got the error logs and that I could get the sleepiq data.

> 2022-03-04 06:03:14 ERROR (MainThread) [homeassistant.components.sleepiq.coordinator] Unexpected error fetching REDACTED@SleepIQ data: 'NoneType' object is not subscriptable
> Traceback (most recent call last):
>   File "/usr/src/homeassistant/homeassistant/helpers/update_coordinator.py", line 187, in _async_refresh
>     self.data = await self._async_update_data()
>   File "/usr/src/homeassistant/homeassistant/components/sleepiq/coordinator.py", line 37, in _async_update_data
>     await self.client.fetch_bed_statuses()
>   File "/usr/local/lib/python3.9/site-packages/asyncsleepiq/asyncsleepiq.py", line 189, in fetch_bed_statuses
>     self.beds[bed_status['bedId']].sleepers[i].in_bed = bed_status[side+'Side']['isInBed']
> TypeError: 'NoneType' object is not subscriptable