### PR TITLE
Add mapping of bed preset name strings to ints

### DIFF
--- a/asyncsleepiq/consts.py
+++ b/asyncsleepiq/consts.py
@@ -20,7 +20,17 @@ FLAT = 4
 ZERO_G = 5
 SNORE = 6
 
-BED_PRESETS = [FAVORITE, READ, WATCH_TV, FLAT, ZERO_G, SNORE]
+NO_PRESET = "Not at preset"
+
+BED_PRESETS = {
+    NO_PRESET: 0,
+    "Favorite": FAVORITE,
+    "Read": READ,
+    "Watch TV": WATCH_TV,
+    "Flat": FLAT,
+    "Zero G": ZERO_G,
+    "Snore": SNORE,
+}
 
 OFF = 0
 LOW = 1

--- a/asyncsleepiq/foundation.py
+++ b/asyncsleepiq/foundation.py
@@ -7,7 +7,6 @@ from .actuator import SleepIQActuator
 from .api import SleepIQAPI
 from .consts import (
     BED_LIGHTS,
-    BED_PRESETS,
     FOUNDATION_TYPES,
     MASSAGE_MODE,
     MASSAGE_SPEED,

--- a/asyncsleepiq/preset.py
+++ b/asyncsleepiq/preset.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 from typing import Any
 from .api import SleepIQAPI
-from .consts import BED_PRESETS, SIDES, SIDES_FULL
+from .consts import BED_PRESETS, NO_PRESET, SIDES, SIDES_FULL
 
 class SleepIQPreset:
     """Foundation preset setting from SleepIQ API."""
@@ -24,16 +24,18 @@ class SleepIQPreset:
         """Return string representation."""
         return f"SleepIQPreset[{self.side}](preset={self.preset})"
 
-    async def set_preset(self, preset: int, slow_speed: bool = False) -> None:
+    async def set_preset(self, preset: str, slow_speed: bool = False) -> None:
         """Set foundation preset."""
         #
         # preset 1-6
         # slowSpeed False=fast, True=slow
         #
+        if preset == NO_PRESET:
+            return
         if preset not in BED_PRESETS:
             raise ValueError("Invalid preset")
         data = {
-            "preset": preset, 
+            "preset": BED_PRESETS[preset], 
             "side": self.side if self.side else "R", 
             "speed": 1 if slow_speed else 0
         }


### PR DESCRIPTION
As discussed in https://github.com/home-assistant/core/pull/68489, keep a mapping of preset names and their corresponding integer in this library so Home Assistant can get the list of names from here.

I also changed the set_preset function to accept the name of the preset instead of the int value, so that Home Assistant doesn't even have to worry about that mapping.

I'm torn about including the "Not at preset" value in this mapping. I wanted that value to appear in the select entity in Home Assistant to indicate to the user when the bed is not at a preset, but that meant I had to anticipate that value being used in the set_preset function. So it just ignores that silently. 