### PR TITLE
Create enums for values

### DIFF
--- a/asyncsleepiq/actuator.py
+++ b/asyncsleepiq/actuator.py
@@ -4,21 +4,21 @@ from __future__ import annotations
 from typing import Any
 
 from .api import SleepIQAPI
-from .consts import ACTUATORS, ACTUATORS_FULL, SIDES, SIDES_FULL
+from .consts import ACTUATORS_FULL, SIDES_FULL, End, Side
 
 
 class SleepIQActuator:
     """Actuator representation for SleepIQ API."""
 
     def __init__(
-        self, api: SleepIQAPI, bed_id: str, side: int | None, actuator: int
+        self, api: SleepIQAPI, bed_id: str, side: Side, actuator: End
     ) -> None:
         """Initialize actuator object."""
         self._api = api
         self.bed_id = bed_id
-        self.side = SIDES[side] if side else None
-        self.side_full = SIDES_FULL[side] if side else None
-        self.actuator = ACTUATORS[actuator]
+        self.side = side
+        self.side_full = SIDES_FULL[side]
+        self.actuator = actuator
         self.actuator_full = ACTUATORS_FULL[actuator]
         self.position = 0
 
@@ -38,7 +38,7 @@ class SleepIQActuator:
             return
         data = {
             "position": position,
-            "side": self.side if self.side else "R",
+            "side": self.side,
             "actuator": self.actuator,
             "speed": 1 if slow_speed else 0,
         }
@@ -46,10 +46,6 @@ class SleepIQActuator:
 
     async def update(self, data: dict[str, Any]) -> None:
         """Update the position of an actuator from the API."""
-        # For non-split actuators, it doesn't matter which side we get the
-        # value from, it'll always be the same for either
-        side_full = self.side_full if self.side_full else "Right"
-
         # The API reports position in hex, but is set with an integer.
         # We'll always show position with an integer value.
-        self.position = int(data[f"fs{side_full}{self.actuator_full}Position"], 16)
+        self.position = int(data[f"fs{self.side_full}{self.actuator_full}Position"], 16)

--- a/asyncsleepiq/bed.py
+++ b/asyncsleepiq/bed.py
@@ -21,9 +21,9 @@ class SleepIQBed:
         self.mac_addr = data["macAddress"]
         self.paused = False
         self.sleepers = [
-            SleepIQSleeper(api, self.id, data[f"sleeper{side}Id"], side)
+            SleepIQSleeper(api, self.id, data[f"sleeper{SIDES_FULL[side]}Id"], side)
             for side in SIDES_FULL
-            if data.get(f"sleeper{side}Id")
+            if data.get(f"sleeper{SIDES_FULL[side]}Id")
         ]
         self.foundation = SleepIQFoundation(api, self.id)
 

--- a/asyncsleepiq/consts.py
+++ b/asyncsleepiq/consts.py
@@ -1,4 +1,5 @@
 """Constants for SleepIQ API Package."""
+import enum
 
 API_URL = "https://prod-api.sleepiq.sleepnumber.com/rest"
 TIMEOUT = 10
@@ -44,10 +45,16 @@ REVITILIZE = 2
 WAVE = 3
 
 MASSAGE_MODE = [OFF, SOOTHE, REVITILIZE, WAVE]
-SIDES = ["L", "R"]
-SIDES_FULL = ["Left", "Right"]
+
+class Side(str, enum.Enum):
+    LEFT = "L"
+    RIGHT = "R"
+    NONE = "R"
+SIDES_FULL = {Side.LEFT: "Left", Side.RIGHT: "Right"}
 
 FOUNDATION_TYPES = ["single", "splitHead", "splitKing", "easternKing"]
 
-ACTUATORS = ["H", "F"]
-ACTUATORS_FULL = ["Head", "Foot"]
+class End(str, enum.Enum):
+    HEAD = "H"
+    FOOT = "F"
+ACTUATORS_FULL = {End.HEAD: "Head", End.FOOT: "Foot"}

--- a/asyncsleepiq/consts.py
+++ b/asyncsleepiq/consts.py
@@ -33,18 +33,21 @@ BED_PRESETS = {
     "Snore": SNORE,
 }
 
-OFF = 0
-LOW = 1
-MEDIUM = 2
-HIGH = 3
+class Speed(int, enum.Enum):
+    OFF = 0
+    LOW = 1
+    MEDIUM = 2
+    HIGH = 3
 
-MASSAGE_SPEED = [OFF, LOW, MEDIUM, HIGH]
+MASSAGE_SPEEDS = [Speed.OFF, Speed.LOW, Speed.MEDIUM, Speed.HIGH]
 
-SOOTHE = 1
-REVITILIZE = 2
-WAVE = 3
+class Mode(int, enum.Enum):
+    OFF = 0
+    SOOTHE = 1
+    REVITILIZE = 2
+    WAVE = 3
 
-MASSAGE_MODE = [OFF, SOOTHE, REVITILIZE, WAVE]
+MASSAGE_MODES = [Mode.OFF, Mode.SOOTHE, Mode.REVITILIZE, Mode.WAVE]
 
 class Side(str, enum.Enum):
     LEFT = "L"

--- a/asyncsleepiq/foundation.py
+++ b/asyncsleepiq/foundation.py
@@ -8,8 +8,6 @@ from .api import SleepIQAPI
 from .consts import (
     BED_LIGHTS,
     FOUNDATION_TYPES,
-    MASSAGE_MODES,
-    MASSAGE_SPEEDS,
     End,
     Mode,
     Side,

--- a/asyncsleepiq/preset.py
+++ b/asyncsleepiq/preset.py
@@ -3,17 +3,17 @@ from __future__ import annotations
 
 from typing import Any
 from .api import SleepIQAPI
-from .consts import BED_PRESETS, NO_PRESET, SIDES, SIDES_FULL
+from .consts import BED_PRESETS, NO_PRESET, SIDES_FULL, Side
 
 class SleepIQPreset:
     """Foundation preset setting from SleepIQ API."""
 
-    def __init__(self, api: SleepIQAPI, bed_id: str, side: int | None) -> None:
+    def __init__(self, api: SleepIQAPI, bed_id: str, side: Side) -> None:
         """Initialize preset setting."""
         self._api = api
         self.bed_id = bed_id
-        self.side = SIDES[side] if side else None
-        self.side_full = SIDES_FULL[side] if side else None
+        self.side = side
+        self.side_full = SIDES_FULL[side]
         self.preset = ""
 
     def __str__(self) -> str:
@@ -36,15 +36,11 @@ class SleepIQPreset:
             raise ValueError("Invalid preset")
         data = {
             "preset": BED_PRESETS[preset], 
-            "side": self.side if self.side else "R", 
+            "side": self.side,
             "speed": 1 if slow_speed else 0
         }
         await self._api.put("bed/" + self.bed_id + "/foundation/preset", data)
 
     async def update(self, data: dict[str, Any]) -> None:
         """Update the position of an actuator from the API."""
-        # For non split foundations, it doesn't matter which side we get the
-        # value from, it'll always be the same for either
-        side_full = self.side_full if self.side_full else "Right"
-
-        self.preset = data[f"fsCurrentPositionPreset{side_full}"]
+        self.preset = data[f"fsCurrentPositionPreset{self.side_full}"]

--- a/asyncsleepiq/sleeper.py
+++ b/asyncsleepiq/sleeper.py
@@ -2,20 +2,21 @@
 from __future__ import annotations
 
 from .api import SleepIQAPI
+from .consts import SIDES_FULL, Side
 
 
 class SleepIQSleeper:
     """Sleeper representation for SleepIQ API."""
 
     def __init__(
-        self, api: SleepIQAPI, bed_id: str, sleeper_id: str, side: str
+        self, api: SleepIQAPI, bed_id: str, sleeper_id: str, side: Side
     ) -> None:
         """Initialize sleeper object."""
         self.api = api
         self.bed_id = bed_id
         self.sleeper_id = sleeper_id
-        self.side = side[0]
-        self.side_full = side
+        self.side = side
+        self.side_full = SIDES_FULL[side]
         self.active = False
         self.name = ""
 


### PR DESCRIPTION
Replace values of digits or single letters with enum classes for type purposes.

Fix issue where the side  of 0, 1, or None all set the right side `SIDES_FULL[side] if side else None` as noted in #10 

@mfugate1 and @[mjn138](https://github.com/mjn138), can you please review as I can't test the split functionality