### PR TITLE
Fixing Timer Value Type Bug

### DIFF
--- a/asyncsleepiq/fuzion/core_climate.py
+++ b/asyncsleepiq/fuzion/core_climate.py
@@ -34,5 +34,5 @@ class SleepIQFuzionCoreClimate(SleepIQCoreClimate):
         data = data.split()
         self.temperature = CoreTemps[data[0].upper()]
         self.is_on = self.temperature > 0
-        self.timer = data[1] if self.is_on else 0
+        self.timer = int(data[1]) if self.is_on else 0
 

--- a/asyncsleepiq/fuzion/foot_warmer.py
+++ b/asyncsleepiq/fuzion/foot_warmer.py
@@ -26,5 +26,5 @@ class SleepIQFuzionFootWarmer(SleepIQFootWarmer):
         data = data.split()
         self.temperature = FootWarmingTemps[data[0].upper()]
         self.is_on = self.temperature > 0
-        self.timer = data[1] if self.is_on else 0
+        self.timer = int(data[1]) if self.is_on else 0
 


### PR DESCRIPTION
I believe this is the last bug. Sorry for the multiple PR's. I tested this locally and didn't run into any issues. But once I had it in Home Assistant it was throwing an error. 

I tested this fix by locally editing the code in my dev environment for the package. With these changes, I am able to successfully set foot warmers and core climates and continue to change them and the timers properly update. 

The update function for core climate and foot warmer was setting the timer value as a string. When attempting to change the setting an error was being thrown comparing a string to an int during the set_mode call when it checks for a valid time value between 0 and 600.

